### PR TITLE
Ignore 0 bytes in some strings when pulling data from OpenEarable v2

### DIFF
--- a/lib/src/models/devices/open_earable_v2.dart
+++ b/lib/src/models/devices/open_earable_v2.dart
@@ -314,6 +314,10 @@ class OpenEarableV2 extends Wearable
       serviceId: deviceInfoServiceUuid,
       characteristicId: _deviceIdentifierCharacteristicUuid,
     );
+    int nullIndex = deviceIdentifierBytes.indexOf(0);
+    if (nullIndex != -1) {
+      deviceIdentifierBytes = deviceIdentifierBytes.sublist(0, nullIndex);
+    }
     return String.fromCharCodes(deviceIdentifierBytes);
   }
 
@@ -327,6 +331,10 @@ class OpenEarableV2 extends Wearable
       serviceId: deviceInfoServiceUuid,
       characteristicId: _deviceFirmwareVersionCharacteristicUuid,
     );
+    int nullIndex = deviceGenerationBytes.indexOf(0);
+    if (nullIndex != -1) {
+      deviceGenerationBytes = deviceGenerationBytes.sublist(0, nullIndex);
+    }
     return String.fromCharCodes(deviceGenerationBytes);
   }
 
@@ -340,6 +348,10 @@ class OpenEarableV2 extends Wearable
       serviceId: deviceInfoServiceUuid,
       characteristicId: _deviceHardwareVersionCharacteristicUuid,
     );
+    int nullIndex = hardwareGenerationBytes.indexOf(0);
+    if (nullIndex != -1) {
+      hardwareGenerationBytes = hardwareGenerationBytes.sublist(0, nullIndex);
+    }
     return String.fromCharCodes(hardwareGenerationBytes);
   }
 


### PR DESCRIPTION
lib/src/models/devices/open_earable_v2.dart: exclude everything after the 0 byte in a string for identifier, hw and sw version